### PR TITLE
include all fsts: flex orth, vowel length neutralization, and isogloss in nahuat orthography transformation

### DIFF
--- a/lexicon/transformations/nahuat_orthography.py
+++ b/lexicon/transformations/nahuat_orthography.py
@@ -1,7 +1,7 @@
 from lexicon.transformations.transducers import fst_handler
 from mesolex.utils import transformation
 
-ORTH_HANDLER = fst_handler.FSTHandler(fst_handler.get_nahuat_att_file())
+ORTH_HANDLER = fst_handler.FSTHandler(fst_handler.get_nahuat_att_file(True, True, True))
 
 
 @transformation(data_field='nahuat_orthography')


### PR DESCRIPTION
This change just activates all of the flexibility in the FST transformation. Orthographic flexibility, vowel-length neutralization, and isogloss alternations (e.g. t vs tl, e vs i, etc) are all switches that can be turned on individually. Based on feedback, it is better for all of these to be turned on simultaneously. 