### PR TITLE
Add word boundaries to thesaurus regex

### DIFF
--- a/query_api/transformations/spanish_thesaurus.py
+++ b/query_api/transformations/spanish_thesaurus.py
@@ -14,4 +14,5 @@ def es_thesaurus_lookup(query_string):
         )
     )
     synonyms.update(set([query_string]))
-    return "\\b(" + "|".join(synonyms) + ")\\b"
+    import pdb;pdb.set_trace
+    return "\y(" + "|".join(synonyms) + ")\y"

--- a/query_api/transformations/spanish_thesaurus.py
+++ b/query_api/transformations/spanish_thesaurus.py
@@ -14,4 +14,4 @@ def es_thesaurus_lookup(query_string):
         )
     )
     synonyms.update(set([query_string]))
-    return "|".join(synonyms)
+    return "( |^)(" + "|".join(synonyms) + ")( |$)"

--- a/query_api/transformations/spanish_thesaurus.py
+++ b/query_api/transformations/spanish_thesaurus.py
@@ -14,4 +14,4 @@ def es_thesaurus_lookup(query_string):
         )
     )
     synonyms.update(set([query_string]))
-    return "( |^)(" + "|".join(synonyms) + ")( |$)"
+    return "\\b(" + "|".join(synonyms) + ")\\b"

--- a/query_api/transformations/utils.py
+++ b/query_api/transformations/utils.py
@@ -24,7 +24,7 @@ def transformation(data_field=None):
                 # if the regex has surrounding word boundaries, replace the
                 # first word boundary symbol with the bos symbol.
                 #
-                if new_value.startswith("\\b"):
+                if new_value.startswith("\y"):
                     new_value = '^' + new_value[1:]
                 else:
                     new_value = '^' + new_value
@@ -34,7 +34,7 @@ def transformation(data_field=None):
                 # if the regex has surrounding word boundaries, replace the 
                 # last word boundary symbol with the eos symbol.
                 #
-                if new_value.endswith("\\b"):
+                if new_value.endswith("\y"):
                     new_value = new_value[:-1] + "$"
                 else:
                     new_value = new_value + '$'

--- a/query_api/transformations/utils.py
+++ b/query_api/transformations/utils.py
@@ -20,10 +20,24 @@ def transformation(data_field=None):
             new_value = transformer_fn(value)
 
             if filter_type in ['begins_with', 'exactly_equals']:
-                new_value = '^' + new_value
+                #
+                # if the regex has surrounding word boundaries, replace the
+                # first word boundary symbol with the bos symbol.
+                #
+                if new_value.startswith("\\b"):
+                    new_value = '^' + new_value[1:]
+                else:
+                    new_value = '^' + new_value
 
             if filter_type in ['ends_with', 'exactly_equals']:
-                new_value = new_value + '$'
+                #
+                # if the regex has surrounding word boundaries, replace the 
+                # last word boundary symbol with the eos symbol.
+                #
+                if new_value.endswith("\\b"):
+                    new_value = new_value[:-1] + "$"
+                else:
+                    new_value = new_value + '$'
 
             return ('regex', new_value)
 


### PR DESCRIPTION
One issue with the thesaurus queries (maybe true of all queries, but perhaps the overlap is less likely in the nahuat queries) is they are just possible words, which could also be substrings of different words, thus causing overmatching. I just added postgres's word boundaries to the regex (`\y`). I also updated the logic around "begins with" and "ends with" to make sure we don't end up with a query that starts with `^` followed by `\y` or ends with `\y` followed by `$`.